### PR TITLE
Merge new AIX features

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ No specific requirements
 | `samba_map_to_guest`           | `bad user`               | Behaviour when unregistered users access the shares.                                                                |
 | `samba_mitigate_cve_2017_7494` | true                     | CVE-2017-7494 mitigation breaks some clients, such as macOS High Sierra.                                            |
 | `samba_netbios_name`           | `{{ ansible_hostname }}` | The NetBIOS name of this server.                                                                                    |
-| `samba_passdb_backend`         | `tdbsam`                 | Password database backend.                                                                                          |
+| `samba_passdb_backend`         | `tdbsam`                 | Password database backend, use `false` if not required.                                                               |
 | `samba_preferred_master`       | true                     | When true, indicates nmbd is a preferred master browser for workgroup                                               |
 | `samba_realm`                  | -                        | Realm domain name                                                                                                   |
 | `samba_printer_type`           | cups                     | value for the global option `printing` and `printcap name`                                                          |

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ The [test playbook](https://github.com/bertvv/ansible-role-samba/blob/docker-tes
 
 ## Dependencies
 
+### AIX
+
+This role assumes that the target AIX server is using the [AIX Toolbox for Linux](https://www.ibm.com/developerworks/aix/library/aix-toolbox) implementation of Yum with access to the `samba` and `samba-client` packages.
+
+### Other
+
 No dependencies.
 
 ## Example Playbook

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ No specific requirements
 
 | Variable                       | Default                  | Comments                                                                                                                     |
 | :---                           | :---                     | :---                                                                                                                         |
-| `samba_apple_extensions`       | no                       | When yes, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below)       |
-| `samba_create_varwww_symlinks` | false                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform) |
+| `samba_apple_extensions`       | no                       | When yes, enables support for Apple specific SMB extensions. Required for Time Machine support to work (see below)           |
+| `samba_bin_dir`                | -                        | Directory where samba is stored.  If not set will seach $PATH.                                                               |
+| `samba_create_varwww_symlinks` | false                    | When true, symlinks are created in web docroot to the shares. (`var/www/` or `/var/www/html` depending on platform)          |
 | `samba_cups_server`            | localhost:631            | Value for the global option `cups server` (only needed when `samba_printer_type` is "cups")                                  |
 | `samba_domain_master`          | true                     | When true, smbd enables WAN-wide browse list collation                                                                       |
 | `samba_global_include`         | -                        | Samba-compatible configuration file with options to be loaded to [global] section (see below)                                |

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ No specific requirements
 | `samba_server_string`          | `fileserver %m`          | Comment string for the server.                                                                                      |
 | `samba_shares_root`            | `/srv/shares`            | Directories for the shares are created under this directory.                                                        |
 | `samba_shares`                 | []                       | List of dicts containing share definitions. See below for details.                                                  |
+| `samba_testparm`               | `testparm`               | OS Path to the Samba [testparm](https://www.samba.org/samba/docs/current/man-html/testparm.1.html) program.  |
 | `samba_users`                  | []                       | List of dicts defining users that can access shares.                                                                |
 | `samba_wins_support`           | true                     | When true, Samba will act as a WINS server                                                                          |
 | `samba_workgroup`              | `WORKGROUP`              | Name of the server workgroup.                                                                                       |
@@ -236,6 +237,7 @@ Pull requests are also very welcome. Please create a topic branch for your propo
 [Bert Van Vreckem](https://github.com/bertvv/) (maintainer),
 [Birgit Croux](https://github.com/birgitcroux),
 [DarkStar1973](https://github.com/DarkStar1973),
+[David Little](https://github.com/d-little),
 [George Hartzell](https://github.com/hartzell),
 [Ian Young](https://github.com/iangreenleaf),
 [Jonas Heinrich](https://github.com/onny),

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,13 +16,10 @@
   listen: "Restart Samba services"
 
 - name: Restart AIX Samba services
-  command:
-    name: "/etc/rc.d/init.d/{{ item }} restart"
+  command: "/etc/rc.d/init.d/{{ item }} restart"
   with_items: "{{ samba_services }}"
   when: ansible_facts['os_family'] == "AIX"
   listen: "Restart Samba services"
-
-
 
 - name: Start Linux Samba services
   vars:
@@ -41,8 +38,7 @@
   listen: "Start Samba services"
 
 - name: Start AIX Samba services
-  command:
-    name: "/etc/rc.d/init.d/{{ item }} start" 
+  command: "/etc/rc.d/init.d/{{ item }} start" 
   with_items: "{{ samba_services }}"
   when: ansible_facts['os_family'] == "AIX"
   listen: "Start Samba services"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,7 +1,48 @@
 # File: roles/samba/handlers/main.yml
 ---
-- name: Restart Samba services
+- name: Restart Linux Samba services  
+  vars:
+    linux_family:
+      - Archlinux
+      - Debian
+      - Gentoo
+      - RedHat
+      - Suse
   service:
     name: "{{ item }}"
     state: restarted
   with_items: "{{ samba_services }}"
+  when: ansible_facts['os_family'] in linux_family
+  listen: "Restart Samba services"
+
+- name: Restart AIX Samba services
+  command:
+    name: "/etc/rc.d/init.d/{{ item }} restart"
+  with_items: "{{ samba_services }}"
+  when: ansible_facts['os_family'] == "AIX"
+  listen: "Restart Samba services"
+
+
+
+- name: Start Linux Samba services
+  vars:
+    linux_family:
+      - Archlinux
+      - Debian
+      - Gentoo
+      - RedHat
+      - Suse
+  service:
+    name: "{{ item }}"
+    state: started
+    enabled: true
+  with_items: "{{ samba_services }}"
+  when: ansible_facts['os_family'] in linux_family
+  listen: "Start Samba services"
+
+- name: Start AIX Samba services
+  command:
+    name: "/etc/rc.d/init.d/{{ item }} start" 
+  with_items: "{{ samba_services }}"
+  when: ansible_facts['os_family'] == "AIX"
+  listen: "Start Samba services"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -24,6 +24,9 @@ galaxy_info:
     - name: ArchLinux
       versions:
         - all
+    - name: AIX
+      versions:
+        - 72
   galaxy_tags:
     - system
     - networking

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -92,7 +92,7 @@
   template:
     src: "{{ samba_global_include }}"
     dest: "{{ samba_configuration_dir }}"
-    validate: 'testparm -s %s'
+    validate: "{{ samba_testparm | default('testparm') }} -s %s"
   when: samba_global_include is defined
   notify:
     - Restart Samba services
@@ -101,7 +101,7 @@
   template:
     src: "{{ samba_homes_include }}"
     dest: "{{ samba_configuration_dir }}"
-    validate: 'testparm -s %s'
+    validate: "{{ samba_testparm | default('testparm') }} -s %s"
   when: samba_homes_include is defined
   notify:
     - Restart Samba services
@@ -110,7 +110,7 @@
   template:
     src: "{{ item.include_file }}"
     dest: "{{ samba_configuration_dir }}"
-    validate: 'testparm -s %s'
+    validate: "{{ samba_testparm | default('testparm') }} -s %s"
   when: item.include_file is defined
   notify:
     - Restart Samba services

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
 - name: Register Samba version
   shell: >
     set -o nounset -o pipefail -o errexit &&
-    smbd --version | sed 's/Version //'
+    {{ samba_bin_dir + '/' | default('') }}smbd --version | sed 's/Version //'
   args:
     executable: /bin/bash
   register: samba_version
@@ -95,7 +95,7 @@
   template:
     dest: "{{ samba_configuration }}"
     src: smb.conf.j2
-    validate: "{{ samba_testparm | default('testparm') }} -s %s"
+    validate: "{{ samba_bin_dir | default('') }}testparm -s %s"
   notify:
     - Restart Samba services
   tags: samba
@@ -104,7 +104,7 @@
   template:
     src: "{{ samba_global_include }}"
     dest: "{{ samba_configuration_dir }}"
-    validate: "{{ samba_testparm | default('testparm') }} -s %s"
+    validate: "{{ samba_bin_dir | default('') }}testparm -s %s"
   when: samba_global_include is defined
   notify:
     - Restart Samba services
@@ -114,7 +114,7 @@
   template:
     src: "{{ samba_homes_include }}"
     dest: "{{ samba_configuration_dir }}"
-    validate: "{{ samba_testparm | default('testparm') }} -s %s"
+    validate: "{{ samba_bin_dir | default('') }}testparm -s %s"
   when: samba_homes_include is defined
   notify:
     - Restart Samba services
@@ -124,7 +124,7 @@
   template:
     src: "{{ item.include_file }}"
     dest: "{{ samba_configuration_dir }}"
-    validate: "{{ samba_testparm | default('testparm') }} -s %s"
+    validate: "{{ samba_bin_dir | default('') }}testparm -s %s"
   when: item.include_file is defined
   notify:
     - Restart Samba services
@@ -153,7 +153,7 @@
 - name: Create Samba users if they don't exist yet
   shell: >
     set -o nounset -o pipefail -o errexit &&
-    (pdbedit --user={{ item.name }} 2>&1 > /dev/null) \
+    ({{ samba_bin_dir|default('') }}pdbedit --user={{ item.name }} 2>&1 > /dev/null) \
     || (echo {{ item.password }}; echo {{ item.password }}) \
     | smbpasswd -s -a {{ item.name }}
   args:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,13 +125,15 @@
   tags: samba
   when: samba_username_map is defined
 
-- name: Start Samba service(s)
-  service:
-    name: "{{ item }}"
-    state: started
-    enabled: true
-  with_items: "{{ samba_services }}"
-  tags: samba
+# Handled by previous notify; if nothing has changed we dont need to start.
+#  If we DO need to start here, AIX needs custom handling
+#- name: Start Samba service(s)
+#  service:
+#    name: "{{ item }}"
+#    state: started
+#   enabled: true
+#  with_items: "{{ samba_services }}"
+#  tags: samba
 
 - name: Create Samba users if they don't exist yet
   shell: >

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,11 +41,13 @@
   tags: samba
 
 - name: Create Samba shares root directory
+  vars: 
+    group: "{{ 'system' if ansible_facts['os_family'] == 'AIX' else 'root'  }}"
   file:
     state: directory
     path: "{{ samba_shares_root }}"
     owner: root
-    group: root
+    group: "{{ group }}"
     mode: '0755'
   when: samba_shares
   tags: samba

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,7 +83,7 @@
   template:
     dest: "{{ samba_configuration }}"
     src: smb.conf.j2
-    validate: 'testparm -s %s'
+    validate: "{{ samba_testparm | default('testparm') }} -s %s"
   notify:
     - Restart Samba services
   tags: samba

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -28,9 +28,11 @@
 
   # Authentication
   security = {{ samba_security }}
+{% if not samba_passdb_backend is sameas false  %}
   passdb backend = {{ samba_passdb_backend }}
+{% endif %}
   map to guest = {{ samba_map_to_guest }}
-{% if samba_guest_account  is defined %}
+{% if samba_guest_account is defined %}
   guest account = {{ samba_guest_account }}
 {% endif %}
 {% if samba_username_map is defined %}

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -81,7 +81,7 @@
 {% endif %}
 
 {% if samba_global_include is defined %}
-  include = {{ samba_global_include }}
+  include = {{ samba_configuration_dir }}/{{ samba_global_include }}
 {% endif %}
 
 {% if samba_load_homes %}
@@ -93,7 +93,7 @@
 {% endif %}
 
 {% if samba_home_include is defined %}
-  include = {{ samba_home_include }}
+  include = {{ samba_configuration_dir }}/{{ samba_home_include }}
 {% endif %}
 
 {% if samba_shares|length > 0 %}
@@ -140,7 +140,7 @@
   directory mode = {{ share.directory_mode|default('0775') }}
   force directory mode = {{ share.force_directory_mode|default('0775') }}
 {% if share.include_file is defined %}
-  include = /etc/samba/{{ share.include_file }}
+  include = {{ samba_configuration_dir }}/{{ share.include_file }}
 {% endif %}
 
 {% endfor %}

--- a/templates/smb.conf.j2
+++ b/templates/smb.conf.j2
@@ -138,7 +138,7 @@
   directory mode = {{ share.directory_mode|default('0775') }}
   force directory mode = {{ share.force_directory_mode|default('0775') }}
 {% if share.include_file is defined %}
-  include = {{ share.include_file }}
+  include = /etc/samba/{{ share.include_file }}
 {% endif %}
 
 {% endfor %}

--- a/vars/os_AIX.yml
+++ b/vars/os_AIX.yml
@@ -1,0 +1,22 @@
+# roles/samba/vars/os_AIX.yml
+---
+# Assumes that the server has yum package manager set up: 
+#  https://www.ibm.com/developerworks/community/blogs/aixpert/entry/AIX_and_yum_Get_those_Open_Source_apps_on_AIX_the_easy_way
+samba_packages:
+  - samba
+  - samba-client
+
+samba_configuration_dir: /etc/samba
+samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
+samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
+
+samba_testparm: /opt/freeware/bin/testparm
+
+samba_services:
+  - smbd
+  - nmbd
+
+samba_www_documentroot: []
+
+# For information on Samba+AIX, an old document, but still valid: 
+#  https://developer.ibm.com/articles/au-aix_sc����

--- a/vars/os_AIX.yml
+++ b/vars/os_AIX.yml
@@ -18,5 +18,5 @@ samba_services:
 
 samba_www_documentroot: []
 
-# For information on Samba+AIX, an old document, but still valid: 
-#  https://developer.ibm.com/articles/au-aix_sc����
+# For information on Samba+AIX, a very old document: 
+#  https://developer.ibm.com/articles/au-aix_samba

--- a/vars/os_AIX.yml
+++ b/vars/os_AIX.yml
@@ -10,7 +10,7 @@ samba_configuration_dir: /etc/samba
 samba_configuration: "{{ samba_configuration_dir }}/smb.conf"
 samba_username_map_file: "{{ samba_configuration_dir }}/smbusers"
 
-samba_testparm: /opt/freeware/bin/testparm
+samba_bin_dir: /opt/freeware/sbin/ 
 
 samba_services:
   - smbd


### PR DESCRIPTION
## AIX Support

AIX Features are not _fully_ fully tested!  I've confirmed that the basic fileshares etc work, but not a lot more than that.  Anything that works in Linux should *in theory* be OK.

I attempted not to touch existing defaults or functionality, there shouldn't be any API changes required with these features

### Changes:

- Added `vars/os_AIX.yml`
- Removed (commented) a task that redundantly(?) restarted services from `tasks/main.yml`
- Refactored the start+restart services handlers to use listeners; added support for AIX family services in `handlers/main.yml`

### New/Changed variables

- `samba_passdb_backend`: can be set to `false` to disable entirely; still defaults to `tdbsam`
- **New** `samba_testparm`: can be set to change the location of the testparm binary; defaults to the existing `testparm`

### Other Notes

Also includes change:
- samba 'additional include' files are now always referenced by absolute path names, ie:
  - was: `include = {{ samba_global_include }}`
  - now: `include = {{ samba_configuration_dir }}/{{ samba_global_include }}`

However, this was fixed in the latest release on the origin master.
